### PR TITLE
Add ctucanfd_ip_core

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,8 @@ A curated list of awesome open source hardware tools, generators, and reusable d
   * AXI4/AIB Bridge RTL
 * [core_ddr3_controller](https://github.com/ultraembedded/core_ddr3_controller)
   * DDR3 memory controller in Verilog for various FPGAs
+* [ctucanfd_ip_core](https://gitlab.fel.cvut.cz/canbus/ctucanfd_ip_core)
+  * CAN with Flexible Data-rate IP Core developed at Department of Measurement of FEE CTU
 * [hdmi](https://github.com/hdl-util/hdmi)
   * Send video/audio over HDMI on an FPGA
 * [i2c](https://github.com/hdl-util/i2c)


### PR DESCRIPTION
CAN with Flexible Data-rate IP Core developed at Department of Measurement of FEE CTU

CTU CAN FD is soft IP-Core written in VHDL which supports ISO and NON-ISO versions of CAN FD protocol. 
CTU CAN FD is NOT a prototype. RTL is compliant with ISO 1198-1:2015. It is tested by ISO 16845-1 2016 sequence in regression run every day. 
RTL is implemented with VHDL-93, synthesizable with most FPGA and ASIC flows. 
TB is implemented with VHDL 2008.