### PR TITLE
Added AutoDMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ A curated list of awesome open source hardware tools, generators, and reusable d
   * FPGA place and route tool
 
 ## Layout Compilers
+* [AutoDMP](https://github.com/NVlabs/AutoDMP)
+  * Auto-placement tool; requires DREAMPlace
 * [align](https://github.com/ALIGN-analoglayout/ALIGN-public)
   * Automatic layout generator for analog circuits
 * [bag](https://github.com/ucb-art/BAG_framework)


### PR DESCRIPTION
Added AutoDMP tool by Nvidia & the University of Texas at Austin.

Not sure if I added it to the right category. "Chip Layout" could also be relevant here, but I noticed DREAMPlace is also under "Layout Compilers". Relevant press release by Nvidia: [https://developer.nvidia.com/blog/autodmp-optimizes-macro-placement-for-chip-design-with-ai-and-gpus/](https://developer.nvidia.com/blog/autodmp-optimizes-macro-placement-for-chip-design-with-ai-and-gpus/)