### PR TITLE
Add links to AutoSVA, AutoCC and MuchiSim

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,10 @@ A curated list of awesome open source hardware tools, generators, and reusable d
   * SMT automatic theorem prover
 * [ilang](https://github.com/PrincetonUniversity/ILAng)
   * Princeton modeling and Verification Platform for SoCs using ILAs
+* [autosva](https://github.com/PrincetonUniversity/AutoSVA)
+  * Generates FV testbenches and SVA properties for RTL modules based on interface annotations + GPT4
+* [autocc](https://github.com/morenes/AutoCC)
+  * A frontend for JG/SBY to automatically discover covert channels in time-shared hardware
 * [pono](https://github.com/upscale-project/pono)
   * Extensible SMT-based model checker implemented in C++.
 * [sby](https://github.com/YosysHQ/sby)
@@ -467,6 +471,8 @@ A curated list of awesome open source hardware tools, generators, and reusable d
   * FPGA-accelerated Cycle-accurate Hardware Simulation in the Cloud
 * [gem5](https://github.com/gem5/gem5)
   * Modular simulator platform for computer-system architecture research
+* [muchisim](https://github.com/PrincetonUniversity/muchisim)
+  * Cycle-level simulator for PPA and cost analysis of distributed multi-chiplet tile-based manycore designs.
 * [ghdl](https://github.com/ghdl/ghdl)
   * VHDL 2008/93/87 simulator
 * [hotspot](https://github.com/uvahotspot/HotSpot)


### PR DESCRIPTION
This PR adds the links of:
**AutoSVA:** A tool which generates FV testbenches and SVA properties for RTL modules based on interface annotations and a GPT4-based flow (https://ieeexplore.ieee.org/document/9586118)

**MuchiSim:** A simulator framework for analysis of perf, energy, area and cost of distributed multi-chiplet tile-based manycore designs

**AutoCC:** Methodology that leverages FPV to automatically discover covert channels in hardware that is time-shared between processes. AutoCC operates at RTL to exhaustively examine any machine state left by a process after a context switch that creates an execution difference. (https://trustworthy.systems/publications/papers/Orenes-Vera_YWHBWM_23.pdf)

Thanks for compiling this list!
