### PR TITLE
Adds Orbit (and removes its prototype legohdl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ A curated list of awesome open source hardware tools, generators, and reusable d
   * Agile physical design component part of UC Berkeley Chipyard framework.
 * [hwtbuildsystem](https://github.com/Nic30/hwtBuildsystem)
   * Library of utils for interaction with the vendor tools.
-* [legohdl](https://github.com/c-rus/legoHDL)
-  * Command line HDL package manager and development tool.
 * [mflowgen](https://github.com/mflowgen/mflowgen)
   * Build-system generator for ASIC and FPGA design-space exploration.
+* [orbit](https://github.com/chaseruskin/orbit)
+  * Package manager and build tool for HDLs.
 * [siliconcompiler](https://github.com/siliconcompiler/siliconcompiler) (R) :star:
   * Modular distributed build system for hardware
 


### PR DESCRIPTION
Hello! Wow, this is an awesome list. Thank you for taking the time to curate this and aggregate this information into a single location. I was even a little surprised to see an old project of mine (legohdl) on this list.

This PR does the following: 
- adds Orbit, a VHDL/Verilog/SystemVerilog package manager and build tool
- removes legohdl (Orbit's first iteration/prototype that has since been publicly archived by me)

Orbit is geared toward FPGA/ASIC development for those developing in VHDL/Verilog/SystemVerilog. I encourage you if you have time to check out the project, and if you think it is good enough for this list, it would be much appreciated for this PR to be approved. Thanks!