### PR TITLE
Add OhmAI, PCB-Thermal-AI, UVMForge to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ A curated list of awesome open source hardware tools, generators, and reusable d
  * hardware agent
 * [Masala-CHAI](https://github.com/jitendra-bhandari/Masala-CHAI)
  * Large-Scale SPICE Netlist Dataset for Analog Circuits
+* [OhmAI](https://github.com/tusharpathaknyu/OhmAI)
+ * AI-powered SPICE circuit generation with real-time ngspice validation ([demo](https://ohmai-761803298484.us-central1.run.app/))
+* [PCB-Thermal-AI](https://github.com/tusharpathaknyu/PCB-Thermal-AI)
+ * ML-based PCB temperature prediction from layout features ([demo](https://pcb-thermal-ai-761803298484.us-central1.run.app/))
+* [UVMForge](https://github.com/tusharpathaknyu/UVMForge)
+ * LLM-powered UVM testbench generator from natural language specifications ([demo](https://uvmforge-761803298484.us-central1.run.app/))
 
 
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ A curated list of awesome open source hardware tools, generators, and reusable d
  * AI-powered SPICE circuit generation with real-time ngspice validation ([demo](https://ohmai-761803298484.us-central1.run.app/))
 * [PCB-Thermal-AI](https://github.com/tusharpathaknyu/PCB-Thermal-AI)
  * ML-based PCB temperature prediction from layout features ([demo](https://pcb-thermal-ai-761803298484.us-central1.run.app/))
+* [PowerElecLLM](https://github.com/tusharpathaknyu/PowerElecLLM)
+ * Benchmark and evaluation framework for LLMs on power electronics design (650 problems, ngspice validation)
 * [UVMForge](https://github.com/tusharpathaknyu/UVMForge)
  * LLM-powered UVM testbench generator from natural language specifications ([demo](https://uvmforge-761803298484.us-central1.run.app/))
 

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,27 @@
+## Summary
+Adds four AI-powered hardware design tools to the AI section:
+
+### Projects Added
+
+| Project | Description | License |
+|---------|-------------|---------|
+| [OhmAI](https://github.com/tusharpathaknyu/OhmAI) | AI-powered SPICE circuit generation with real-time ngspice validation | MIT |
+| [PCB-Thermal-AI](https://github.com/tusharpathaknyu/PCB-Thermal-AI) | ML-based PCB temperature prediction from layout features | MIT |
+| [PowerElecLLM](https://github.com/tusharpathaknyu/PowerElecLLM) | Benchmark & evaluation framework for LLMs on power electronics (650 problems, ngspice validation) | MIT |
+| [UVMForge](https://github.com/tusharpathaknyu/UVMForge) | LLM-powered UVM testbench generator from natural language specifications | MIT |
+
+### Checklist
+- [x] Link to source code repository
+- [x] Open source projects (MIT License)
+- [x] Working projects (all have live demos)
+- [x] One tag line sentence per project
+- [x] Alphabetically ordered within AI section
+
+### Live Demos
+Three projects have working demos deployed on Google Cloud Run:
+- OhmAI: https://ohmai-761803298484.us-central1.run.app/
+- PCB-Thermal-AI: https://pcb-thermal-ai-761803298484.us-central1.run.app/
+- UVMForge: https://uvmforge-761803298484.us-central1.run.app/
+
+### Benchmarks
+- **PowerElecLLM**: 650 hand-crafted power electronics problems with ngspice validation. Evaluated GPT-4o (25% Pass@1), LLaMA 3.3 70B (2.3% Pass@1). Includes fine-tuning pipeline.


### PR DESCRIPTION
## Summary
Adds three AI-powered hardware design tools to the AI section:

### Projects Added

| Project | Description | License |
|---------|-------------|---------|
| [OhmAI](https://github.com/tusharpathaknyu/OhmAI) | AI-powered SPICE circuit generation with real-time ngspice validation | MIT |
| [PCB-Thermal-AI](https://github.com/tusharpathaknyu/PCB-Thermal-AI) | ML-based PCB temperature prediction from layout features | MIT |
| [UVMForge](https://github.com/tusharpathaknyu/UVMForge) | LLM-powered UVM testbench generator from natural language specifications | MIT |

### Checklist
- [x] Link to source code repository
- [x] Open source projects (MIT License)
- [x] Working projects (all have live demos)
- [x] One tag line sentence per project
- [x] Alphabetically ordered within AI section

### Live Demos
All projects have working demos deployed on Google Cloud Run:
- OhmAI: https://ohmai-761803298484.us-central1.run.app/
- PCB-Thermal-AI: https://pcb-thermal-ai-761803298484.us-central1.run.app/
- UVMForge: https://uvmforge-761803298484.us-central1.run.app/
