### PR TITLE
Add synth-explorer to Circuit Compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ A curated list of awesome open source hardware tools, generators, and reusable d
   * Translates synthesizable SystemC to synthesizable Verilog
 * [synlig](https://github.com/chipsalliance/synlig)
   * SystemVerilog support for Yosys
+* [synth-explorer](https://github.com/cachanova/synth-explorer)
+  * Browser-based Compiler Explorer for RTL that runs Yosys and GHDL in WebAssembly to synthesize and inspect netlists client-side
 * [tapasco](https://github.com/esa-tu-darmstadt/tapasco)
   * Heterogeneous system composer
 * [tce](https://github.com/cpc/tce)


### PR DESCRIPTION
Adds **synth-explorer** — a browser-based Compiler Explorer for RTL. Paste Verilog/SystemVerilog/VHDL and it synthesizes with Yosys + GHDL (compiled to WebAssembly) fully client-side, then lets you inspect the resulting netlist by path, fanin/fanout, and source line.

- Source: https://github.com/cachanova/synth-explorer (Apache-2.0, open source)
- Live demo: https://www.synthexplorer.dev

Placed alphabetically in **Circuit Compilers**, following the list requirements: source-repo link, open-source, working project, one tagline sentence.