### PR TITLE
Add gds-lens to Layout Compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ A curated list of awesome open source hardware tools, generators, and reusable d
   * Platform for chip design and layout
 * [gds3d](https://github.com/trilomix/GDS3D)
   * Render GDS files in 3D
+* [gds-lens](https://github.com/EthanLowenthal/GDS-Lens)
+  * VS Code extension for viewing GDSII and OASIS layouts
 * [gdsiistl](https://github.com/dteal/gdsiistl)
   * Converts GDSII files to STL files
 * [gdstk](https://github.com/heitzmann/gdstk)


### PR DESCRIPTION
Adds GDS Lens, an MIT-licensed VS Code extension that opens .gds/.oas
files in a custom editor and renders them in WebGL2. Supports KLayout
.lyp layer colors and DRC/LVS marker databases (.lyrdb, Calibre ASCII).

Meets the listed requirements: open source (MIT), working project with
tagged releases, source repo, single-sentence description.